### PR TITLE
MicroBench: Add Proxy and absent properties microbenchmarks

### DIFF
--- a/MicroBench/pic-get-absent.js
+++ b/MicroBench/pic-get-absent.js
@@ -1,0 +1,9 @@
+function go() {
+  const a = { x: 1 };
+
+  for (let i = 0; i < 50_000_000; ++i) {
+    a.nonexistent;
+  }
+}
+
+go();

--- a/MicroBench/proxy-call-00-args.js
+++ b/MicroBench/proxy-call-00-args.js
@@ -1,0 +1,15 @@
+function go() {
+  function target() {}
+
+  const p = new Proxy(target, {
+    apply(t, thisArg, args) {
+      return t.apply(thisArg, args);
+    },
+  });
+
+  for (let i = 0; i < 10_000_000; ++i) {
+    p();
+  }
+}
+
+go();

--- a/MicroBench/proxy-call-01-args.js
+++ b/MicroBench/proxy-call-01-args.js
@@ -1,0 +1,16 @@
+function go() {
+  function target(event) {}
+
+  const p = new Proxy(target, {
+    apply(t, thisArg, args) {
+      return t.apply(thisArg, args);
+    },
+  });
+
+  const event = {};
+  for (let i = 0; i < 10_000_000; ++i) {
+    p(event);
+  }
+}
+
+go();

--- a/MicroBench/proxy-call-04-args.js
+++ b/MicroBench/proxy-call-04-args.js
@@ -1,0 +1,15 @@
+function go() {
+  function target() {}
+
+  const p = new Proxy(target, {
+    apply(t, thisArg, args) {
+      return t.apply(thisArg, args);
+    },
+  });
+
+  for (let i = 0; i < 10_000_000; ++i) {
+    p(1, 2, 3, 4);
+  }
+}
+
+go();

--- a/MicroBench/proxy-call-no-trap.js
+++ b/MicroBench/proxy-call-no-trap.js
@@ -1,0 +1,11 @@
+function go() {
+  function target() {}
+
+  const p = new Proxy(target, {});
+
+  for (let i = 0; i < 10_000_000; ++i) {
+    p(1);
+  }
+}
+
+go();

--- a/MicroBench/proxy-get-trap-with-bind.js
+++ b/MicroBench/proxy-get-trap-with-bind.js
@@ -1,0 +1,31 @@
+function go() {
+  function handler(event) {}
+  const listener = { handleEvent: handler };
+  const cache = new WeakMap();
+
+  const p = new Proxy(listener, {
+    get(target, prop, receiver) {
+      if (prop === "handleEvent") {
+        const fn = target[prop];
+        if (fn) {
+          let wrapped = cache.get(fn);
+          if (!wrapped) {
+            wrapped = function (e) {
+              return fn.call(this, e);
+            };
+            cache.set(fn, wrapped);
+          }
+          return wrapped.bind(target);
+        }
+      }
+      return Reflect.get(target, prop, receiver);
+    },
+  });
+
+  const event = {};
+  for (let i = 0; i < 10_000_000; ++i) {
+    p.handleEvent(event);
+  }
+}
+
+go();

--- a/MicroBench/proxy-get-trap.js
+++ b/MicroBench/proxy-get-trap.js
@@ -1,0 +1,17 @@
+function go() {
+  function handler(event) {}
+  const listener = { handleEvent: handler };
+
+  const p = new Proxy(listener, {
+    get(target, prop, receiver) {
+      return Reflect.get(target, prop, receiver);
+    },
+  });
+
+  const event = {};
+  for (let i = 0; i < 10_000_000; ++i) {
+    p.handleEvent(event);
+  }
+}
+
+go();

--- a/MicroBench/proxy-nested-call.js
+++ b/MicroBench/proxy-nested-call.js
@@ -1,0 +1,22 @@
+function go() {
+  function target(event) {}
+
+  const inner = new Proxy(target, {
+    apply(t, thisArg, args) {
+      return t.apply(thisArg, args);
+    },
+  });
+
+  const outer = new Proxy(inner, {
+    apply(t, thisArg, args) {
+      return t.apply(thisArg, args);
+    },
+  });
+
+  const event = {};
+  for (let i = 0; i < 10_000_000; ++i) {
+    outer(event);
+  }
+}
+
+go();


### PR DESCRIPTION
```
Suite       Test                                    Mean ± σ       Range (min … max)    Max RSS (mean)
----------  --------------------------------------  -------------  -------------------  ----------------
MicroBench  array-destructuring-assignment-rest.js  0.270 ± 0.002  0.268 … 0.271        30.8 MB
MicroBench  array-destructuring-assignment.js       1.892 ± 0.083  1.835 … 1.987        2793.2 MB
MicroBench  array-prototype-map.js                  1.008 ± 0.003  1.006 … 1.012        310.7 MB
MicroBench  array-prototype-shift.js                0.016 ± 0.001  0.015 … 0.017        15.3 MB
MicroBench  bound-call-00-args.js                   1.257 ± 0.064  1.210 … 1.330        14.8 MB
MicroBench  bound-call-04-args.js                   1.320 ± 0.021  1.295 … 1.334        14.8 MB
MicroBench  bound-call-16-args.js                   1.585 ± 0.031  1.564 … 1.621        14.8 MB
MicroBench  call-00-args.js                         0.290 ± 0.004  0.286 … 0.295        14.7 MB
MicroBench  call-01-args.js                         0.308 ± 0.001  0.307 … 0.309        14.7 MB
MicroBench  call-02-args.js                         0.318 ± 0.006  0.314 … 0.326        14.7 MB
MicroBench  call-03-args.js                         0.327 ± 0.005  0.322 … 0.331        14.7 MB
MicroBench  call-04-args.js                         0.333 ± 0.004  0.329 … 0.338        14.7 MB
MicroBench  call-16-args.js                         0.510 ± 0.002  0.509 … 0.512        14.7 MB
MicroBench  call-32-args.js                         0.712 ± 0.009  0.702 … 0.720        14.7 MB
MicroBench  for-in-indexed-properties.js            0.153 ± 0.000  0.152 … 0.153        170.4 MB
MicroBench  for-in-named-properties.js              0.144 ± 0.006  0.140 … 0.150        15.0 MB
MicroBench  for-of.js                               0.451 ± 0.002  0.449 … 0.453        14.8 MB
MicroBench  object-keys.js                          1.286 ± 0.011  1.278 … 1.299        187.3 MB
MicroBench  object-set-with-rope-strings.js         0.421 ± 0.003  0.418 … 0.425        15.3 MB
MicroBench  pic-add-own.js                          0.421 ± 0.003  0.418 … 0.424        32.4 MB
MicroBench  pic-get-absent.js                       1.480 ± 0.049  1.424 … 1.509        14.7 MB
MicroBench  pic-get-own.js                          0.385 ± 0.001  0.384 … 0.386        14.8 MB
MicroBench  pic-get-pchain.js                       0.386 ± 0.002  0.384 … 0.388        14.8 MB
MicroBench  pic-put-own.js                          0.364 ± 0.003  0.360 … 0.366        14.8 MB
MicroBench  pic-put-pchain.js                       1.501 ± 0.045  1.466 … 1.552        14.8 MB
MicroBench  proxy-call-00-args.js                   1.474 ± 0.015  1.463 … 1.490        26.1 MB
MicroBench  proxy-call-01-args.js                   1.376 ± 0.006  1.369 … 1.379        33.1 MB
MicroBench  proxy-call-04-args.js                   1.671 ± 0.025  1.653 … 1.699        33.2 MB
MicroBench  proxy-call-no-trap.js                   0.578 ± 0.001  0.577 … 0.579        14.8 MB
MicroBench  proxy-get-trap-with-bind.js             6.045 ± 0.012  6.031 … 6.053        49.1 MB
MicroBench  proxy-get-trap.js                       1.091 ± 0.012  1.079 … 1.104        14.8 MB
MicroBench  proxy-nested-call.js                    3.487 ± 0.059  3.419 … 3.526        33.2 MB
MicroBench  setter-in-prototype-chain.js            1.790 ± 0.015  1.773 … 1.800        14.9 MB
MicroBench  short-string-concat.js                  0.276 ± 0.003  0.273 … 0.279        14.8 MB
MicroBench  strictly-equals-object.js               0.662 ± 0.014  0.645 … 0.672        14.7 MB
```