### PR TITLE
Add a MicroBench for object spread syntax

### DIFF
--- a/MicroBench/object-spread.js
+++ b/MicroBench/object-spread.js
@@ -1,0 +1,20 @@
+function go() {
+  let source = {
+    a: 1,
+    b: 2,
+    c: 3,
+    d: 4,
+    e: 5,
+    f: 6,
+    g: 7,
+    h: 8,
+  };
+
+  let sink;
+  for (let i = 0; i < 5_000_000; ++i) {
+    sink = { ...source };
+  }
+  return sink;
+}
+
+go();


### PR DESCRIPTION
This was used to measure the performance improvement to a fast path in `CopyDataProperties`.